### PR TITLE
fix: update product details route to use only slug param

### DIFF
--- a/frontend/vite-project/src/App.tsx
+++ b/frontend/vite-project/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
             <Route path="/shop" element={<Shop />} />
             <Route path="/login" element={<Login />} />
             <Route path="/signup" element={<Signup />} />
-            <Route path="/products/:id/:slug" element={<ProductDetails />} />
+            <Route path="/products/:slug" element={<ProductDetails />} />
             <Route path="/checkout/shipping" element={<Shipping />} />
             <Route path="/checkout/select-shipping" element={<ShippingSelectorPage />} />
             <Route path="/checkout/payment" element={<PaymentForm />} />


### PR DESCRIPTION
Update product details route to use only slug param

In a previous PR, the route was accidentally reverted back to the old URL with both :id and :slug. This PR restores the correct route, using only the :slug parameter (/products/:slug).