### PR TITLE
chore: configure backend and frontend for Vercel deployment

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -3,10 +3,11 @@
   "version": "1.0.0",
   "main": "src/server.ts",
   "scripts": {
-    "start": "ts-node src/server.ts",
+    "start": "node dist/server.js",
     "dev": "nodemon --watch src --ext ts --exec ts-node src/server.ts",
     "run:schema": "ts-node src/utils/runSchema.ts",
-    "seed": "ts-node src/utils/runSeed.ts"
+    "seed": "ts-node src/utils/runSeed.ts",
+    "build": "tsc"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -55,6 +55,10 @@ app.get("/", (_req, res) => {
 
 app.use("/docs", swaggerUi.serve, swaggerUi.setup(swaggerDocument));
 
-app.listen(PORT, () => {
-  console.log(`Server running on http://localhost:${PORT}`);
-});
+if (process.env.NODE_ENV !== "production") {
+  app.listen(PORT, () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+  });
+}
+
+export default app;

--- a/backend/vercel.json
+++ b/backend/vercel.json
@@ -1,0 +1,9 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "src/server.ts", "use": "@vercel/node" }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "src/server.ts" }
+  ]
+}

--- a/frontend/vite-project/src/components/purchased-seeds/SeedCard.tsx
+++ b/frontend/vite-project/src/components/purchased-seeds/SeedCard.tsx
@@ -71,7 +71,7 @@ const SeedCard = ({
     setIsLoadingSaveChanges(true);
     try {
       const response = await axios.put(
-        "http://localhost:5000/user-tasks/update",
+        `${import.meta.env.VITE_API_URL}/user-tasks/update`,
         tasksToUpdate,
         {
           headers: {

--- a/frontend/vite-project/src/hooks/useCredentialForm.ts
+++ b/frontend/vite-project/src/hooks/useCredentialForm.ts
@@ -65,7 +65,7 @@ export const useCredentialForm = (
         if (formType === "signup") {
           console.log(result.data);
           const response = await axios.post(
-            "http://localhost:5000/auth-test/complete-signup",
+            `${import.meta.env.VITE_API_URL}/auth-test/complete-signup`,
             {},
             {
               headers: {
@@ -79,7 +79,7 @@ export const useCredentialForm = (
         } else if (formType === "login") {
           console.log(result.data);
           const response = await axios.post(
-            "http://localhost:5000/auth-test/link-tasks",
+            `${import.meta.env.VITE_API_URL}/auth-test/link-tasks`,
             {},
             {
               headers: {

--- a/frontend/vite-project/src/pages/DashBoard.tsx
+++ b/frontend/vite-project/src/pages/DashBoard.tsx
@@ -22,7 +22,7 @@ function DashBoard() {
       setIsFetchingTasks(true);
       try {
         const response = await axios.get<UserTasksResponse>(
-          "http://localhost:5000/user-tasks",
+          `${import.meta.env.VITE_API_URL}/user-tasks`,
           {
             headers: {
               "Content-Type": "application/json",

--- a/frontend/vite-project/src/pages/ProductDetails.tsx
+++ b/frontend/vite-project/src/pages/ProductDetails.tsx
@@ -26,7 +26,7 @@ const ProductDetails: React.FC = () => {
     const fetchPlant = async () => {
       try {
         const res = await axios.get<ProductItem[]>(
-          "http://localhost:5000/plants"
+          `${import.meta.env.VITE_API_URL}/plants`
         ); // fetch all plants but if you're using a different port, adjust the URL accordingly
         const data = res.data;
         console.log(data);
@@ -46,7 +46,7 @@ const ProductDetails: React.FC = () => {
 
     const fetchTasks = async () => {
       try {
-        const res = await axios.get(`http://localhost:5000/plants/${plant.id}/tasks`);
+        const res = await axios.get(`${import.meta.env.VITE_API_URL}/plants/${plant.id}/tasks`);
         setTasks(res.data);
       } catch (err) {
         setTasks([]);

--- a/frontend/vite-project/src/socialAuthHandlers/facebookOAuth.ts
+++ b/frontend/vite-project/src/socialAuthHandlers/facebookOAuth.ts
@@ -4,7 +4,7 @@ export const handleFacebookLogin = async () => {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: "facebook",
     options: {
-      redirectTo: "http://localhost:5173/dashboard",
+      redirectTo: `${import.meta.env.VITE_OAUTH_REDIRECT_URL}/dashboard`,
     },
   });
   if (error) {

--- a/frontend/vite-project/src/socialAuthHandlers/googleOAuth.ts
+++ b/frontend/vite-project/src/socialAuthHandlers/googleOAuth.ts
@@ -4,7 +4,7 @@ export const handleGoogleLogin = async () => {
   const { error } = await supabase.auth.signInWithOAuth({
     provider: "google",
     options: {
-      redirectTo: "http://localhost:5173/dashboard",
+      redirectTo: `${import.meta.env.VITE_OAUTH_REDIRECT_URL}/dashboard`,
     },
   });
   if (error) {

--- a/frontend/vite-project/src/stores/productsStore.ts
+++ b/frontend/vite-project/src/stores/productsStore.ts
@@ -35,7 +35,7 @@ const useProductsStore = create<ProductState>((set) => ({
   actions: {
     fetchAllPlants: async () => {
       set({ loading: true })
-      const response = await axios.get("http://localhost:5000/plants");
+      const response = await axios.get(`${import.meta.env.VITE_API_URL}/plants`);
       console.log(response.data);
       set({
         productList: response.data,

--- a/frontend/vite-project/src/stores/searchStore.ts
+++ b/frontend/vite-project/src/stores/searchStore.ts
@@ -28,7 +28,7 @@ export const useSearchStore = create<SearchState>((set, get) => ({
             if (!query) return [];
             set({ loading: true, submittedQuery: query });
             try {
-                const response = await axios.get(`http://localhost:5000/plants/search?name=${encodeURIComponent(query)}`);
+                const response = await axios.get(`${import.meta.env.VITE_API_URL}/plants/search?name=${encodeURIComponent(query)}`);
                 const data = response.data.data;
                 set({ results: data, loading: false });
                 console.log("New search Zustand Store:", response.data.data);

--- a/frontend/vite-project/src/stores/shippingOptionStore.ts
+++ b/frontend/vite-project/src/stores/shippingOptionStore.ts
@@ -23,7 +23,7 @@ export const useSelectedShippingOption = () =>
 const useShippingOptionsStore = create<ShippingOptionsState>((set) => {
   const fetchAllOptions = async () => {
     try {
-      const response = await axios.get("http://localhost:5000/shipping-options");
+      const response = await axios.get(`${import.meta.env.VITE_API_URL}/shipping-options`);
       set({ allShippingOptions: response.data });
     } catch (error) {
       console.error(error);

--- a/frontend/vite-project/src/utils/handleTransaction.ts
+++ b/frontend/vite-project/src/utils/handleTransaction.ts
@@ -23,7 +23,7 @@ export const handleTransaction = async (
 
   try {
     const response = await axios.post(
-      `http://localhost:5000/${endpoint}`,
+      `${import.meta.env.VITE_API_URL}/${endpoint}`,
       payload,
       {
         method: "POST",


### PR DESCRIPTION
**Prepare Backend and Frontend for Vercel Deployment**

**What was done**

_Backend_

- Refactored server.ts to export the Express app for Vercel Serverless Functions.
- Ensured app.listen only runs in non-production environments.
- Added/updated vercel.json to configure Vercel builds and routing.
- Confirmed all environment variables are loaded from .env and documented for Vercel setup.

_Frontend_

- Replaced all hardcoded API URLs (localhost) with import.meta.env.VITE_API_URL.
- Updated OAuth redirect URLs to use environment variables.
- Searched and updated all files that make backend requests to use environment variables.

_Why_
- To enable seamless deployment of both backend and frontend on Vercel.
- To ensure the application works correctly in both local and production environments.
- To make configuration and environment management easier and safer.

**Observation:**
Add the following lines to your frontend `.env` file to ensure local development works correctly:

- VITE_API_URL=http://localhost:5000
- VITE_OAUTH_REDIRECT_URL=http://localhost:5173

After deploying our backend to Vercel, we will need to update the servers section in our swagger.yaml with our new production URL. For example:
```
servers:
  - url: https://our-backend.vercel.app
  - url: http://localhost:5000
```
This ensures our Swagger documentation reflects both our production and local API endpoints.